### PR TITLE
Fix dynamic config (should be same on all servers)

### DIFF
--- a/templates/zoo.cfg.dynamic.j2
+++ b/templates/zoo.cfg.dynamic.j2
@@ -1,11 +1,6 @@
 {%- set ips = [] %}
 {%- for host in groups[zk_inventory_group] %}
-{% if host == inventory_hostname %}
-{%- set zk_address_local = '0.0.0.0' %}
-{% else %}
-{%- set zk_address_local = hostvars[host]['zk_address'] %}
-{% endif %}
-{{- ips.append(dict(id=loop.index, host=host, ip=zk_address_local, role=hostvars[host]['zk_server_role'])) }}
+{{- ips.append(dict(id=loop.index, host=host, ip=hostvars[host]['zk_address'], role=hostvars[host]['zk_server_role'])) }}
 {%- endfor %}
 
 {% for server in ips %}


### PR DESCRIPTION
## Description

For now there is not any motivation to use server's local address and moreover it's almost impossible, since zookeeper propagate dynamic config to all servers. Official docs it clearly states:  

> The dynamic parameters are pushed by ZooKeeper and overwrite the dynamic configuration files on all servers. Thus, the dynamic configuration files on the different servers are usually identical (they can only differ momentarily when a reconfiguration is in progress, or if a new configuration hasn't propagated yet to some of the servers). 

see: https://zookeeper.apache.org/doc/r3.6.1/zookeeperReconfig.html#sc_reconfig_file

As result of such propagation I have invalid dynamic config on 2 of 3 servers (except last one that was restarted).

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Reviews

- [ ] @tgadiev 
- [ ] @ViachaslauKabak 

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass with my changes
